### PR TITLE
코드스멜 예외처리

### DIFF
--- a/src/main/java/Buzzer.java
+++ b/src/main/java/Buzzer.java
@@ -84,6 +84,7 @@ public class Buzzer implements Runnable {
             beepThread.join();
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
         interval = INTERVALS[1];
         volume = VOLUMES[2];

--- a/src/main/java/Stopwatch.java
+++ b/src/main/java/Stopwatch.java
@@ -49,6 +49,7 @@ public class Stopwatch extends Function {
             stopwatch.getTimeThread().join();
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
         changeMode(0);
     }

--- a/src/main/java/System.java
+++ b/src/main/java/System.java
@@ -134,6 +134,7 @@ public class System extends Function {
                     }
                 } catch (InterruptedException e) {
                     e.printStackTrace();
+                    Thread.currentThread().interrupt();
                 }
             }
         });
@@ -1239,6 +1240,7 @@ public class System extends Function {
             buzzer.getBeepThread().join();
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/src/main/java/Time.java
+++ b/src/main/java/Time.java
@@ -1,6 +1,7 @@
 import java.text.SimpleDateFormat;
 import java.lang.System;
 import java.lang.Runnable;
+import java.util.Objects;
 
 class Time implements Runnable {
 
@@ -35,12 +36,17 @@ class Time implements Runnable {
 
     @Override
     public boolean equals(Object t) {
-        if (t == null || !(t instanceof Time))
+        if (!(t instanceof Time))
             return false;
         Time time = (Time)t;
         if (time.hour < 0 || time.hour > 23 || time.min < 0 || time.min > 59 || time.sec < 0 || time.sec > 59)
             return false;
         return hour == time.hour && min == time.min && sec == time.sec;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hour, min, sec);
     }
 
     public Time(int timeFlag) {
@@ -170,8 +176,8 @@ class Time implements Runnable {
                     std = cur;
                 }
             } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
                 e.printStackTrace();
+                Thread.currentThread().interrupt();
             }
 
         }

--- a/src/main/java/TimeKeeping.java
+++ b/src/main/java/TimeKeeping.java
@@ -291,6 +291,7 @@ public class TimeKeeping extends Function {
             curTime.getTimeThread().join();
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
 
         curTime.setTime(timeSettingValue[0], timeSettingValue[1], timeSettingValue[2]);

--- a/src/main/java/Timer.java
+++ b/src/main/java/Timer.java
@@ -91,6 +91,7 @@ public class Timer extends Function {
             timer.getTimeThread().join();
         } catch (InterruptedException e) {
             e.printStackTrace();
+            Thread.currentThread().interrupt();
         }
         changeMode(0);
     }


### PR DESCRIPTION
1. InterruptedException에서 로깅하는 것 뿐만 아니라 현재 쓰레드에서 인터럽트를 던져야 함.
2. Equals 오버라이딩 하면 hashcode 역시 오버라이딩 해야함. 컬렉션 프레임워크에서 객체의 hashcode를 먼저 참조하기 때문에 같이 해주어야 함. 버그는 없지만 버그의 가능성이 있어 수정함.